### PR TITLE
Hand-optimizing performance of approximated tanh/sigmoid

### DIFF
--- a/src/approx.rs
+++ b/src/approx.rs
@@ -1,0 +1,44 @@
+/// Raw transmutation from `u32`.
+///
+/// Converts the given `u32` containing the float's raw memory representation into the `f32` type.
+/// Similar to `f32::from_bits` but even more raw.
+#[inline]
+pub fn from_bits(x: u32) -> f32 {
+    unsafe { ::std::mem::transmute::<u32, f32>(x) }
+}
+
+/// Raises 2 to a floating point power.
+//#[inline]
+//pub fn pow2(p: f32) -> f32 {
+//    let v = (8388608.0_f32 * p + 1064872507.1541044_f32) as u32;
+//    from_bits(v)
+//}
+
+/// Exponential function.
+#[inline]
+pub fn exp(p: f32) -> f32 {
+    //pow2(1.442695040_f32 * p)
+    let v = (12102203.15410432_f32 * p + 1064872507.1541044_f32) as u32;
+    from_bits(v)
+
+}
+
+#[inline]
+pub fn exp_m2(p: f32) -> f32 {
+    //pow2(-2.0 * 1.442695040_f32 * p)
+    let v = (-24204406.30820864_f32 * p + 1064872507.1541044_f32) as u32;
+    from_bits(v)
+
+}
+
+/// Sigmoid function.
+#[inline]
+pub fn approx_nsigmoid(x: f32) -> f32 {
+    1.0_f32 / (1.0_f32 + exp(x))
+}
+
+/// Hyperbolic tangent function.
+#[inline]
+pub fn approx_tanh(p: f32) -> f32 {
+    -1.0_f32 + 2.0_f32 / (1.0_f32 + exp_m2(p))
+}

--- a/src/conv_layer.rs
+++ b/src/conv_layer.rs
@@ -1,6 +1,7 @@
 use ndarray::linalg::general_mat_mul;
 use ndarray::{Array, Ix1, Ix2};
 use crate::matrix_load::*;
+use crate::approx::*;
 use std::io::BufRead;
 use std::error::Error;
 use std::marker::PhantomData;
@@ -82,7 +83,7 @@ impl<CS: ConvSizer> ConvLayer<CS> {
         unsafe {
             let ptr = self.pooled_out.as_mut_ptr();
             for i in 0..self.pooled_out.len() as isize {
-                *ptr.offset(i) = fastapprox::faster::tanh(*ptr.offset(i))
+                *ptr.offset(i) = approx_tanh(*ptr.offset(i))
             }
         }
     }

--- a/src/gru_layer.rs
+++ b/src/gru_layer.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::io::BufRead;
 use ndarray::linalg::general_mat_mul;
 use crate::matrix_load::*;
+use crate::approx::*;
 use libc::c_void;
 use std::marker::PhantomData;
 
@@ -97,7 +98,7 @@ impl<GS: GRUSizer> GRULayer<GS> {
                     let sptr = sample.as_ptr();
                     let bptr = self.biur.as_ptr();
 		    for i in 0..2*GS::output_features() as isize {
-                        *ptr.offset(i) = 1.0 / (1.0 + fastapprox::faster::exp(*ptr.offset(i) + *sptr.offset(i) + *bptr.offset(i)));
+                        *ptr.offset(i) = approx_nsigmoid(*ptr.offset(i) + *sptr.offset(i) + *bptr.offset(i));
                     }
                 }
             }
@@ -124,7 +125,7 @@ impl<GS: GRUSizer> GRULayer<GS> {
 
 		for i in 0..GS::output_features() as isize {
                     *stptr.offset(i) = *old_st_ptr.offset(i) * *ptr.offset(i)
-                            + (1.0 - *ptr.offset(i)) * fastapprox::faster::tanh(*nvptr.offset(i));
+                            + (1.0 - *ptr.offset(i)) * approx_tanh(*nvptr.offset(i));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate libc;
 mod matrix_load;
 mod conv_layer;
 mod gru_layer;
+mod approx;
 
 use matrix_load::*;
 use conv_layer::*;


### PR DESCRIPTION
Gains about 5% of performance. Should be equivalent to the old approximation within the range -126-126
